### PR TITLE
Changes by Mike Rawlins, GXS, March 15, 2013. Changes to support String array for class level RequestMapping

### DIFF
--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -272,10 +272,13 @@ public class AnnotationProcessor extends AbstractProcessor {
             return path;
         else if (clsAnno.value().length == 1)
             return Utils.joinPaths(path, clsAnno.value()[0]);
-        else
-            throw new IllegalStateException(String.format(
-                    "The RequestMapping annotation of class %s has multiple value strings. Only zero or one value is supported",
-                    cls.getQualifiedName()));
+        else {  // Modified Mike Rawlins 2013-03-15 - support multiple values for request mapping
+            String urlString = "[ " + clsAnno.value()[0];
+            for (int i = 1; i < clsAnno.value().length; i++) {
+                urlString = urlString + " || " + clsAnno.value()[i];
+            }
+            return urlString + " ]";
+        }
     }
 
     private class TypeVisitorImpl extends AbstractTypeVisitor6<JsonType,Void> {

--- a/src/main/java/org/versly/rest/wsdoc/Utils.java
+++ b/src/main/java/org/versly/rest/wsdoc/Utils.java
@@ -20,6 +20,12 @@ public class Utils {
     static final String SERIALIZED_RESOURCE_LOCATION = "org.versly.rest.wsdoc.web-service-api.ser";
 
     static String joinPaths(String lhs, String rhs) {
+
+        // Mike Rawlins 2013-03-15 Don't append slash if right hand side is empty
+        if (rhs == null || rhs.length() == 0) {
+            return lhs;
+        }
+
         while (lhs.endsWith("/"))
             lhs = lhs.substring(0, lhs.length() - 1);
 


### PR DESCRIPTION
value for class level RequestMapping. Output is similar to style used
in Tomcat log: [ /v1/mysource || /current/myresource ] /theRest

Fix joinPaths to not append slash if right hand side is empty string.
