### PR TITLE
Matching Calendar to timestamp

### DIFF
--- a/src/main/java/org/versly/rest/wsdoc/impl/JsonPrimitive.java
+++ b/src/main/java/org/versly/rest/wsdoc/impl/JsonPrimitive.java
@@ -56,6 +56,7 @@ public class JsonPrimitive implements JsonType, Serializable {
         _primitiveTypeNamesByJavaTypeName.put(UUID.class.getName(), "uuid");
 
         _primitiveTypeNamesByJavaTypeName.put(Date.class.getName(), "timestamp");
+        _primitiveTypeNamesByJavaTypeName.put(java.util.Calendar.class.getName(), "timestamp");
         _primitiveTypeNamesByJavaTypeName.put(java.sql.Date.class.getName(), "date");
         _primitiveTypeNamesByJavaTypeName.put(java.sql.Time.class.getName(), "time");
         _primitiveTypeNamesByJavaTypeName.put(Timestamp.class.getName(), "timestamp");


### PR DESCRIPTION
The Calendar object was missing, default conversion to json should be as timestamp.
