### PR TITLE
Handle error case in AnnotationProcessor where we hit unsupported types.

### DIFF
--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -557,10 +557,17 @@ public class AnnotationProcessor extends AbstractProcessor {
         @Override
         public JsonType visitTypeVariable(TypeVariable typeVariable, Void o) {
             DeclaredType type = getDeclaredTypeForTypeVariable(typeVariable);
-            if (type != null) // null: un-parameterized usage of a generics-having type
-                return type.accept(this, o);
-            else
+            if (type != null) { // null: un-parameterized usage of a generics-having type
+                try {
+                    return type.accept(this, o);
+                } catch (UnsupportedOperationException e) {
+                    // likely we ran into a type we can't work with (e.g. ErrorType), continue with best effort
+                    return null;
+                }
+            }
+            else {
                 return null;
+            }
         }
 
         private DeclaredType getDeclaredTypeForTypeVariable(TypeVariable typeVariable) {


### PR DESCRIPTION
Witnessed a problem where annotation processing was failing when visiting an ErrorType.  We can't do anything interesting with these, but seemed better to continue with best effort than fail-fast.

@pcl 
