### PR TITLE
Fix for issue #32 : Ability to skip documenting certain classes and meth...

### DIFF
--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.versly.rest.wsdoc.DocumentationScope.Scope;
 import org.versly.rest.wsdoc.impl.JaxRSRestImplementationSupport;
 import org.versly.rest.wsdoc.impl.JsonArray;
 import org.versly.rest.wsdoc.impl.JsonDict;
@@ -160,8 +161,8 @@ public class AnnotationProcessor extends AbstractProcessor {
     	
     	while(executableElement.getKind().compareTo(ElementKind.PACKAGE) != 0) {
     	
-    		UnDocumented unDocumented = executableElement.getAnnotation(UnDocumented.class);
-    		if (unDocumented != null && unDocumented.value()) {
+    		DocumentationScope unDocumented = executableElement.getAnnotation(DocumentationScope.class);
+    		if (unDocumented != null && unDocumented.value() == Scope.Internal) {
     			return true;
     		}
     	

--- a/src/main/java/org/versly/rest/wsdoc/DocumentationScope.java
+++ b/src/main/java/org/versly/rest/wsdoc/DocumentationScope.java
@@ -1,0 +1,21 @@
+package org.versly.rest.wsdoc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Define this annotation on the method or on a class with Scope.Internal, to skip documenting it.
+ * 
+ * @author aisac
+ *
+ */
+@Target(ElementType.TYPE)
+public @interface DocumentationScope {
+	
+	public enum Scope {
+		Internal,	//Internal, will not include in API documentation
+		External	//Will include it in documentation.
+	}
+	
+	Scope value() default Scope.External;
+}

--- a/src/main/java/org/versly/rest/wsdoc/UnDocumented.java
+++ b/src/main/java/org/versly/rest/wsdoc/UnDocumented.java
@@ -1,9 +1,0 @@
-package org.versly.rest.wsdoc;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-@Target(ElementType.TYPE)
-public @interface UnDocumented {
-	boolean value() default true;
-}


### PR DESCRIPTION
We had some internal REST APIs that we did not want to be included in the REST API Documentation meant for our customers. I added a new annotation @UnDocumented that could be defined on a class or method which will skip documenting. There are ways this could be improved further to make it even granular.
