### PR TITLE
bump annotation processing support to Java 8 source

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently, wsdoc is available in source format only. To install, you'll need mvn
     cd wsdoc
     mvn install
 
-Once you've done this, the wsdoc jar will be available in your local Maven repository, probably at ~/.m2/repository/org/versly/versly-wsdoc/1.0-SNAPSHOT/versly-wsdoc-1.0-SNAPSHOT.jar
+Once you've done this, the wsdoc jar will be available in your local Maven repository, probably at ~/.m2/repository/org/versly/versly-wsdoc/1.1-SNAPSHOT/versly-wsdoc-1.1-SNAPSHOT.jar
 
 <a id="running"/>
 #### Running wsdoc
@@ -277,7 +277,7 @@ be subsequently augmented with text that describes the semantics of each trait.
                     <dependency>
                         <groupId>org.versly</groupId>
                         <artifactId>versly-wsdoc</artifactId>
-                        <version>1.0-SNAPSHOT</version>
+                        <version>1.1-SNAPSHOT</version>
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Often, a single REST API is implemented across a number of web archives. As a re
 
 4\. Enjoy the output at web-service-api.html
 
+Note, with release 1.1-SNAPSHOT, wsdoc requires a Java 8 runtime at annotations processing time.  This will not impose any requirements, however, on the source version or target runtime of the processed Java code.
+
 <a id="samples"/>
 #### Sample Input and Output
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.versly</groupId>
     <artifactId>versly-wsdoc</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <url>http://github.com/versly/wsdoc</url>
 
     <repositories>

--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -58,7 +58,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 //   - plural RequestMapping value support (i.e., two paths bound to one method)
 //   - support for methods not marked with @RequestMapping whose class does have a @RequestMapping annotation
 @SupportedAnnotationTypes({"org.springframework.web.bind.annotation.RequestMapping", "javax.ws.rs.Path"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class AnnotationProcessor extends AbstractProcessor {
 
     private RestDocumentation _docs = new RestDocumentation();

--- a/src/main/java/org/versly/rest/wsdoc/DocumentationRestApi.java
+++ b/src/main/java/org/versly/rest/wsdoc/DocumentationRestApi.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface DocumentationRestApi {
     String id() default "(default)";
-    String mount() default "/";
+    String mount() default "";
     String title() default "";
     String version() default "";
 }


### PR DESCRIPTION
In theory, this should be necessary to process annotations in Java 8 source, but I've found that Java 8 source processes okay w/o it.  I'm guessing I just haven't found the right Java 8'isms to make it angry so I think it's a good idea to bump this anyway.  

I've made a commensurate bump to the wsdoc version itself, to 1.1-SNAPSHOT, so that folks still working in older Java environments still have a patch-path that doesn't require upgrading Java, and added a note to the README.md to explain the change.

EDIT: found a case where explicitly supporting RELEASE_8 is necessary, so this will in fact be needed.

EDIT: bump

@pcl