### PR TITLE
Fix base URI derivation and simplify RestDocAssembler.writeDocumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Once you've done this, the wsdoc jar will be available in your local Maven repos
 <a id="running"/>
 #### Running wsdoc
 
+With version 1.1-SNAPSHOT, wsdoc now requires a Java 8 runtime at annotations processing time.  This does not impose any requirements, however, on the source version or target runtime of the processed Java code.
+
 Often, a single REST API is implemented across a number of web archives. As a result, wsdoc is designed to run in two passes: a data-gathering pass (implemented via Java annotation processor) and an output-assembly pass (implemented as a standalone Java program):
 
 1\. Generate the wsdoc interim data. This will create a file called org.versly.rest.wsdoc.web-service-api.ser in your build output directory. This file should be included as a resource in your web archive (at WEB-INF/classes/org.versly.rest.wsdoc.web-service-api.ser)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently, wsdoc is available in source format only. To install, you'll need mvn
     cd wsdoc
     mvn install
 
-Once you've done this, the wsdoc jar will be available in your local Maven repository, probably at ~/.m2/repository/org/versly/versly-wsdoc/1.0-SNAPSHOT/versly-wsdoc-1.0-SNAPSHOT.jar
+Once you've done this, the wsdoc jar will be available in your local Maven repository, probably at ~/.m2/repository/org/versly/versly-wsdoc/1.1-SNAPSHOT/versly-wsdoc-1.1-SNAPSHOT.jar
 
 <a id="running"/>
 #### Running wsdoc
@@ -39,6 +39,8 @@ Often, a single REST API is implemented across a number of web archives. As a re
     java org.versly.rest.wsdoc.RestDocAssembler *.war *.ser
 
 4\. Enjoy the output at web-service-api.html
+
+Note, with release 1.1-SNAPSHOT, wsdoc requires a Java 8 runtime at annotations processing time.  This will not impose any requirements, however, on the source version or target runtime of the processed Java code.
 
 <a id="samples"/>
 #### Sample Input and Output
@@ -277,7 +279,7 @@ be subsequently augmented with text that describes the semantics of each trait.
                     <dependency>
                         <groupId>org.versly</groupId>
                         <artifactId>versly-wsdoc</artifactId>
-                        <version>1.0-SNAPSHOT</version>
+                        <version>1.1-SNAPSHOT</version>
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.versly</groupId>
     <artifactId>versly-wsdoc</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <url>http://github.com/versly/wsdoc</url>
 
     <repositories>

--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -58,7 +58,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 //   - plural RequestMapping value support (i.e., two paths bound to one method)
 //   - support for methods not marked with @RequestMapping whose class does have a @RequestMapping annotation
 @SupportedAnnotationTypes({"org.springframework.web.bind.annotation.RequestMapping", "javax.ws.rs.Path"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class AnnotationProcessor extends AbstractProcessor {
 
     private RestDocumentation _docs = new RestDocumentation();

--- a/src/main/java/org/versly/rest/wsdoc/DocumentationRestApi.java
+++ b/src/main/java/org/versly/rest/wsdoc/DocumentationRestApi.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface DocumentationRestApi {
     String id() default "(default)";
-    String mount() default "/";
+    String mount() default "";
     String title() default "";
     String version() default "";
 }

--- a/src/main/java/org/versly/rest/wsdoc/RestDocAssembler.java
+++ b/src/main/java/org/versly/rest/wsdoc/RestDocAssembler.java
@@ -112,33 +112,8 @@ public class RestDocAssembler {
         } else {
             filteredApis = aggregatedApis.values();
         }
-        
-        // derive the common base URI for all resources of each API and make that the API mount
-        for (RestDocumentation.RestApi api : aggregatedApis.values()) {
-            String basePath = null;
-            for (RestDocumentation.RestApi.Resource resource : api.getResources()) {
-                String resourcePath = resource.getPath();
-                if (null != resourcePath) {
-                    if (null == basePath) {
-                        basePath = resourcePath;
-                    }
-                    else {
-                        String[] baseParts = basePath.split("/");
-                        String[] resourceParts = resourcePath.split("/");
-                        basePath = "";
-                        int smallerLength = Math.min(baseParts.length, resourceParts.length);
-                        for (int i = 0; i < smallerLength && baseParts[i].equals(resourceParts[i]); ++i) {
-                            if (baseParts[i].length() > 0) {
-                                basePath += "/" + baseParts[i];
-                            }
-                        }
-                    }
-                }
-            }
-            api.setMount(basePath);
-        }
 
-        // use command-line --scope value to set the scope on which to filter the generated documentation
+        // use command-line --scope value to filter the generated documentation
         if (!scope.equals("all")) {
             HashSet<String> requestedScopes = new HashSet<String>(Arrays.asList(new String[]{scope}));
 
@@ -166,7 +141,32 @@ public class RestDocAssembler {
                 }
             }
         }
-        
+
+        // derive the common base URI for all resources of each API and declare that the API mount
+        for (RestDocumentation.RestApi api : filteredApis) {
+            String basePath = null;
+            for (RestDocumentation.RestApi.Resource resource : api.getResources()) {
+                String resourcePath = resource.getPath();
+                if (null != resourcePath) {
+                    if (null == basePath) {
+                        basePath = resourcePath;
+                    }
+                    else {
+                        String[] baseParts = basePath.split("/");
+                        String[] resourceParts = resourcePath.split("/");
+                        basePath = "";
+                        int smallerLength = Math.min(baseParts.length, resourceParts.length);
+                        for (int i = 0; i < smallerLength && baseParts[i].equals(resourceParts[i]); ++i) {
+                            if (baseParts[i].length() > 0) {
+                                basePath += "/" + baseParts[i];
+                            }
+                        }
+                    }
+                }
+            }
+            api.setMount(basePath);
+        }
+
         Configuration conf = new Configuration();
         conf.setClassForTemplateLoading(RestDocAssembler.class, "");
         conf.setObjectWrapper(new DefaultObjectWrapper());

--- a/src/main/java/org/versly/rest/wsdoc/RestDocAssembler.java
+++ b/src/main/java/org/versly/rest/wsdoc/RestDocAssembler.java
@@ -113,6 +113,31 @@ public class RestDocAssembler {
             filteredApis = aggregatedApis.values();
         }
         
+        // derive the common base URI for all resources of each API and make that the API mount
+        for (RestDocumentation.RestApi api : aggregatedApis.values()) {
+            String basePath = null;
+            for (RestDocumentation.RestApi.Resource resource : api.getResources()) {
+                String resourcePath = resource.getPath();
+                if (null != resourcePath) {
+                    if (null == basePath) {
+                        basePath = resourcePath;
+                    }
+                    else {
+                        String[] baseParts = basePath.split("/");
+                        String[] resourceParts = resourcePath.split("/");
+                        basePath = "";
+                        int smallerLength = Math.min(baseParts.length, resourceParts.length);
+                        for (int i = 0; i < smallerLength && baseParts[i].equals(resourceParts[i]); ++i) {
+                            if (baseParts[i].length() > 0) {
+                                basePath += "/" + baseParts[i];
+                            }
+                        }
+                    }
+                }
+            }
+            api.setMount(basePath);
+        }
+
         // use command-line --scope value to set the scope on which to filter the generated documentation
         if (!scope.equals("all")) {
             HashSet<String> requestedScopes = new HashSet<String>(Arrays.asList(new String[]{scope}));

--- a/src/main/java/org/versly/rest/wsdoc/RestDocAssembler.java
+++ b/src/main/java/org/versly/rest/wsdoc/RestDocAssembler.java
@@ -86,11 +86,10 @@ public class RestDocAssembler {
         this(outputFileName, "html");
     }
 
-    List<String> writeDocumentation(List<RestDocumentation> docs, Iterable<Pattern> excludePatterns, String scope)
-        throws IOException, ClassNotFoundException, TemplateException {
-        List<String> filesWritten = new ArrayList<String>();
-        
-        // combine APIs from the REST docs into one map, merging those with matching identifiers
+    /**
+     * combine APIs from the REST docs into one map, merging those APIs with matching identifiers
+     */
+    private Collection<RestDocumentation.RestApi> mergeApis(List<RestDocumentation> docs) {
         Map<String,RestDocumentation.RestApi> aggregatedApis = new LinkedHashMap<String,RestDocumentation.RestApi>();
         for (RestDocumentation doc : docs) {
             for (RestDocumentation.RestApi api : doc.getApis()) {
@@ -102,15 +101,23 @@ public class RestDocAssembler {
                 }
             }
         }
+        return aggregatedApis.values();
+    }
+
+    /**
+     * Filter out APIs based on user provided exclude patterns and selected scope (scope of 'all' implies no filtering).
+     */
+    private Collection<RestDocumentation.RestApi> filterApis(
+            Collection<RestDocumentation.RestApi> apis, Iterable<Pattern> excludePatterns, String scope) {
 
         // filter doc objects by client provided exclude patterns
         Collection<RestDocumentation.RestApi> filteredApis = null;
         if (excludePatterns != null) {
             filteredApis = new LinkedList<RestDocumentation.RestApi>();
-            for (RestDocumentation.RestApi api : aggregatedApis.values())
+            for (RestDocumentation.RestApi api : apis)
                 filteredApis.add(api.filter(excludePatterns));
         } else {
-            filteredApis = aggregatedApis.values();
+            filteredApis = apis;
         }
 
         // use command-line --scope value to filter the generated documentation
@@ -141,17 +148,22 @@ public class RestDocAssembler {
                 }
             }
         }
+        
+        return filteredApis;
+    }
 
-        // derive the common base URI for all resources of each API and declare that the API mount
-        for (RestDocumentation.RestApi api : filteredApis) {
+    /**
+     * derive the common base URI for all resources in each API and declare that the API mount point.
+     */
+    private void deriveBaseURIs(Collection<RestDocumentation.RestApi> apis) {
+        for (RestDocumentation.RestApi api : apis) {
             String basePath = null;
             for (RestDocumentation.RestApi.Resource resource : api.getResources()) {
                 String resourcePath = resource.getPath();
                 if (null != resourcePath) {
                     if (null == basePath) {
                         basePath = resourcePath;
-                    }
-                    else {
+                    } else {
                         String[] baseParts = basePath.split("/");
                         String[] resourceParts = resourcePath.split("/");
                         basePath = "";
@@ -166,13 +178,27 @@ public class RestDocAssembler {
             }
             api.setMount(basePath);
         }
+    }
+
+    List<String> writeDocumentation(List<RestDocumentation> docs, Iterable<Pattern> excludePatterns, String scope)
+        throws IOException, ClassNotFoundException, TemplateException {
+        List<String> filesWritten = new ArrayList<String>();
+        
+        // combine APIs from the REST docs into one map, merging those with matching identifiers
+        Collection<RestDocumentation.RestApi> apis = mergeApis(docs);
+
+        // filter out APIs based on exclude patterns and selected publishing scope
+        apis = filterApis(apis, excludePatterns, scope);
+
+        // derive the common base URI for all resources of each API and declare that the API mount
+        deriveBaseURIs(apis);
 
         Configuration conf = new Configuration();
         conf.setClassForTemplateLoading(RestDocAssembler.class, "");
         conf.setObjectWrapper(new DefaultObjectWrapper());
         Writer out = null;
         try {
-            for (RestDocumentation.RestApi api : filteredApis) {
+            for (RestDocumentation.RestApi api : apis) {
                 Template template = conf.getTemplate(_outputTemplate);
                 Map<String, RestDocumentation.RestApi> root = new HashMap<String, RestDocumentation.RestApi>();
                 root.put("api", api);


### PR DESCRIPTION
For RAML generation it is useful to have the base URI documented at API scope.  Since resources may be grouped into a common API from multiple controller classes, each with potentially different mount points, this fix derives the most specific path that all resources of a merged API have in common. 

Note, this pull request depends on pull request #37.

@pcl