### PR TITLE
fix broken build and set version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.versly</groupId>
     <artifactId>versly-wsdoc</artifactId>
     <packaging>jar</packaging>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.005</version>
     <url>http://github.com/versly/wsdoc</url>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.versly</groupId>
     <artifactId>versly-wsdoc</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.005</version>
+    <version>1.1.005</version>
     <url>http://github.com/versly/wsdoc</url>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <compilerArgument>-proc:none</compilerArgument>
                     <source>1.6</source>
                     <target>1.6</target>
                 </configuration>

--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,1 @@
-org.versly.rest.wsdoc.RestAnnotationProcessoor
+org.versly.rest.wsdoc.AnnotationProcessor


### PR DESCRIPTION
Service loader trying to use the processor to process itself (also fixed error in processor class name).

Also set the version in the pom.xml to 1.1.005.  I'm happy to roll that back, though, if a different value is preferred or setting version isn't something we want to do at this time.

@pcl