### PR TITLE
fix automated service loading and give @AuthorizationScope runtime retention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
         </dependency>
 
         <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-          <version>3.1</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
         </dependency>
 
 
@@ -131,7 +131,34 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <!-- the services profile includes jar metadata to automate service(s) loading -->
+        <profile>
+            <id>services</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>src/main/resources</directory>
+                        <includes>
+                            <include>META-INF/services/*</include>
+                        </includes>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
+        <!-- do not include automated service(s) loading by default -->
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>META-INF/services/*</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
         <plugins>
             <!-- Compile defaults to 1.3! Gotta override -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.versly</groupId>
     <artifactId>versly-wsdoc</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.005</version>
+    <version>1.1.006</version>
     <url>http://github.com/versly/wsdoc</url>
 
     <repositories>

--- a/src/main/java/org/versly/rest/wsdoc/AuthorizationScope.java
+++ b/src/main/java/org/versly/rest/wsdoc/AuthorizationScope.java
@@ -1,6 +1,8 @@
 package org.versly.rest.wsdoc;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -8,6 +10,7 @@ import java.lang.annotation.Target;
  * for access to the annotated REST endpoint(s).  It may be applied at either the class or method level.  The
  * if applied at both levels, the effect is to recognize the union of scopes from both levels.
  */
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
 public @interface AuthorizationScope {
     String[] value() default {};


### PR DESCRIPTION
Automated service loading via ServiceLoader should be opt-in, as it can result in unexpected and detrimental behavior in projects that wish to use the annotation processor in an explicitly executed model.  This PR moves the configuration of automated service loading to a "services" profile, and produces an ordinary jar archive by default.

Also changed the @AuthorizationScope annotation retention policy to runtime, so that it can be used for programmatic enforcement of same.

@pcl 