### PR TITLE
Method-level @AuthorizationScope to override class-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,22 +252,24 @@ be subsequently augmented with text that describes the semantics of each trait.
 
 The `@AuthorizationScope` annotation may be used to assign one or more OAuth2 authorization scopes to a given endpoint
 handler or to an entire controller.  For example, a controller may be annotated to permit authorization for all contained
-endpoint handlers based on one of several scopes declared at the class level, such as `two_scope_service:write` and
-`two_scope_service:admin`.  It may then also permit authorization for particular contained endpoint handlers based on
-additional scopes declared at the method level, such as `two_scope_service:read`.  This might look as follows.
+endpoint handlers based on one of several scopes declared at the class level, such as `two_scope_service:read` and
+`two_scope_service:admin`.  It may alternatively permit authorization for particular contained endpoint handlers based on
+ scopes declared at the method level, such as `two_scope_service:write`.  This might look as follows.
 
-    @AuthorizationScope( { "two_scope_service:write", "two_scope_service:admin" } )
+    @AuthorizationScope( { "two_scope_service:read", "two_scope_service:admin" } )
     public static class TwoScopeController {
 
-        @AuthorizationScope("two_scope_service:read")
-        @RequestMapping(value = "/twoscope", method = RequestMethod.GET)
+        @AuthorizationScope("two_scope_service:write")
+        @RequestMapping(value = "/twoscope", method = RequestMethod.POST)
         public void get() {
         }
 
-        @RequestMapping(value = "/twoscope", method = RequestMethod.POST)
+        @RequestMapping(value = "/twoscope", method = RequestMethod.GET)
         public void post() {
         }
     }
+
+Note that method-level declarations will override class-level declarations.
 
 <a id="maven"/>
 #### wsdoc in a Maven build environment

--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -197,13 +197,15 @@ public class AnnotationProcessor extends AbstractProcessor {
                 // set authorization scope on method (auth scope is non-scalar, methods can have multiple auth scopes)
                 {
                     HashSet<String> authScopes = new HashSet<String>();
-                    AuthorizationScope clsAuthScopes = cls.getAnnotation(AuthorizationScope.class);
-                    if (null != clsAuthScopes) {
-                        authScopes.addAll(Arrays.asList(clsAuthScopes.value()));
-                    }
                     AuthorizationScope methodAuthScopes = executableElement.getAnnotation(AuthorizationScope.class);
                     if (null != methodAuthScopes) {
                         authScopes.addAll(Arrays.asList(methodAuthScopes.value()));
+                    }
+                    else {
+                        AuthorizationScope clsAuthScopes = cls.getAnnotation(AuthorizationScope.class);
+                        if (null != clsAuthScopes) {
+                            authScopes.addAll(Arrays.asList(clsAuthScopes.value()));
+                        }
                     }
                     method.setAuthScopes(authScopes);
                 }
@@ -211,13 +213,15 @@ public class AnnotationProcessor extends AbstractProcessor {
                 // set traits on method (traits is non-scalar, methods may have multiple traits)
                 {
                     HashSet<String> traits = new HashSet<String>(method.getDocScopes());
-                    DocumentationTraits clsTraits = cls.getAnnotation(DocumentationTraits.class);
-                    if (null != clsTraits) {
-                        traits.addAll(Arrays.asList(clsTraits.value()));
-                    }
                     DocumentationTraits methodTraits = executableElement.getAnnotation(DocumentationTraits.class);
                     if (null != methodTraits) {
                         traits.addAll(Arrays.asList(methodTraits.value()));
+                    }
+                    else {
+                        DocumentationTraits clsTraits = cls.getAnnotation(DocumentationTraits.class);
+                        if (null != clsTraits) {
+                            traits.addAll(Arrays.asList(clsTraits.value()));
+                        }
                     }
                     method.setTraits(traits);
                 }

--- a/src/test/java/org/versly/rest/wsdoc/AbstractRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/AbstractRestAnnotationProcessorTest.java
@@ -471,7 +471,7 @@ public abstract class AbstractRestAnnotationProcessorTest {
 
         resource = raml.getResource("/twoscopes/api/v1/twoscope");
         AssertJUnit.assertNotNull("RAML has no twoscope controller", resource);
-        action = resource.getAction(ActionType.GET);
+        action = resource.getAction(ActionType.POST);
         AssertJUnit.assertNotNull("RAML twoscope controller has no get action", action);
         secRef = action.getSecuredBy();
         AssertJUnit.assertNotNull("RAML has no twoscope security reference list", secRef);
@@ -482,11 +482,11 @@ public abstract class AbstractRestAnnotationProcessorTest {
         AssertJUnit.assertEquals("RAML twoscope secref parameters map does not contain one entry", 1, parameters.size());
         List<String> scopes = parameters.get("scopes");
         AssertJUnit.assertNotNull("RAML twoscope secref parameters map does not contain scopes", scopes);
-        AssertJUnit.assertTrue("RAML twoscope secref parameters does not include two_scope_service:read scope", scopes.contains("two_scope_service:read"));
         AssertJUnit.assertTrue("RAML twoscope secref parameters does not include two_scope_service:write scope", scopes.contains("two_scope_service:write"));
-        AssertJUnit.assertTrue("RAML twoscope secref parameters does not include two_scope_service:admin scope", scopes.contains("two_scope_service:admin"));
+        AssertJUnit.assertTrue("RAML twoscope secref parameter includes two_scope_service:read scope", !scopes.contains("two_scope_service:read"));
+        AssertJUnit.assertTrue("RAML twoscope secref parameters includes two_scope_service:admin scope", !scopes.contains("two_scope_service:admin"));
 
-        action = resource.getAction(ActionType.POST);
+        action = resource.getAction(ActionType.GET);
         AssertJUnit.assertNotNull("RAML twoscope controller has no post action", action);
         secRef = action.getSecuredBy();
         AssertJUnit.assertNotNull("RAML has no twoscope security reference list", secRef);
@@ -497,8 +497,8 @@ public abstract class AbstractRestAnnotationProcessorTest {
         AssertJUnit.assertEquals("RAML twoscope secref parameters map does not contain one entry", 1, parameters.size());
         scopes = parameters.get("scopes");
         AssertJUnit.assertNotNull("RAML twoscope secref parameters map does not contain scopes", scopes);
-        AssertJUnit.assertTrue("RAML twoscope secref parameters includes two_scope_service:read scope", !scopes.contains("two_scope_service:read"));
-        AssertJUnit.assertTrue("RAML twoscope secref parameters does not include two_scope_service:write scope", scopes.contains("two_scope_service:write"));
+        AssertJUnit.assertTrue("RAML twoscope secref parameters does not include two_scope_service:read scope", scopes.contains("two_scope_service:read"));
+        AssertJUnit.assertTrue("RAML twoscope secref parameters includes two_scope_service:write scope", !scopes.contains("two_scope_service:write"));
         AssertJUnit.assertTrue("RAML twoscope secref parameters does not include two_scope_service:admin scope", scopes.contains("two_scope_service:admin"));
     }
 

--- a/src/test/resources/org/versly/rest/wsdoc/jaxrs/AuthorizationScopes.java
+++ b/src/test/resources/org/versly/rest/wsdoc/jaxrs/AuthorizationScopes.java
@@ -26,16 +26,16 @@ public class AuthorizationScopes {
      */
     @RestApiMountPoint("/twoscopes")
     @Path("/api/v1")
-    @AuthorizationScope( { "two_scope_service:write", "two_scope_service:admin" } )
+    @AuthorizationScope( { "two_scope_service:read", "two_scope_service:admin" } )
     public static class TwoScopeController {
 
-        @AuthorizationScope("two_scope_service:read")
-        @GET
+        @AuthorizationScope("two_scope_service:write")
+        @POST
         @Path("/twoscope")
         public void get() {
         }
 
-        @POST
+        @GET
         @Path("/twoscope")
         public void post() {
         }

--- a/src/test/resources/org/versly/rest/wsdoc/springmvc/AuthorizationScopes.java
+++ b/src/test/resources/org/versly/rest/wsdoc/springmvc/AuthorizationScopes.java
@@ -24,16 +24,16 @@ public class AuthorizationScopes {
      */
     @RestApiMountPoint("/twoscopes")
     @RequestMapping("/api/v1")
-    @AuthorizationScope( { "two_scope_service:write", "two_scope_service:admin" } )
+    @AuthorizationScope( { "two_scope_service:read", "two_scope_service:admin" } )
     public static class TwoScopeController {
 
-        @AuthorizationScope("two_scope_service:read")
-        @RequestMapping(value = "/twoscope", method = RequestMethod.GET)
-        public void get() {
-        }
-
+        @AuthorizationScope("two_scope_service:write")
         @RequestMapping(value = "/twoscope", method = RequestMethod.POST)
         public void post() {
+        }
+
+        @RequestMapping(value = "/twoscope", method = RequestMethod.GET)
+        public void get() {
         }
     }
 }


### PR DESCRIPTION
This is a minor change to have method-level annotations, such as @AuthorizationScope and @DocumentationTraits, override their class-level equivalents.  The initial design was to take the union of the two, which has proven unpopular.

@pcl - I know you're busy but wanted to at least give you a chance to review.  This is a minor change so if I don't hear back in a day or so I'll go ahead and merge.