### PR TITLE
Add support for templatizing mount point, id etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,27 @@ endpoint handlers based on one of several scopes declared at the class level, su
 
 Note that method-level declarations will override class-level declarations.
 
+* Using templates in REST documentation
+
+In cases where REST mount-point, description etc. are not available during the annotation processing phase, a user can annotate such values with special markers:
+
+    @DocumentationRestApi(
+            id = DocumentationRestApi.ID_TEMPLATE,
+            title = DocumentationRestApi.TITLE_TEMPLATE,
+            version = DocumentationRestApi.VERSION_TEMPLATE,
+            mount = DocumentationRestApi.MOUNT_TEMPLATE)
+    public class RestApi4 {
+    }
+
+During documentation generation, the user can pass in the actual values as follows:
+
+    java org.versly.rest.wsdoc.RestDocAssembler \
+            --template-id rest4 \
+            --template-title "REST API 4" \
+            --template-version v1 \
+            --template-mount /restapi4/api \
+            *.ser
+
 <a id="maven"/>
 #### wsdoc in a Maven build environment
 

--- a/src/main/java/org/versly/rest/wsdoc/DocumentationRestApi.java
+++ b/src/main/java/org/versly/rest/wsdoc/DocumentationRestApi.java
@@ -5,6 +5,11 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
 public @interface DocumentationRestApi {
+    String ID_TEMPLATE = "@WSDOC_ID@";
+    String MOUNT_TEMPLATE = "@WSDOC_MOUNT@";
+    String TITLE_TEMPLATE = "@WSDOC_TITLE@";
+    String VERSION_TEMPLATE = "@WSDOC_VERSION@";
+
     String id() default "(default)";
     String mount() default "";
     String title() default "";

--- a/src/main/java/org/versly/rest/wsdoc/RestDocAssembler.java
+++ b/src/main/java/org/versly/rest/wsdoc/RestDocAssembler.java
@@ -40,6 +40,10 @@ public class RestDocAssembler {
         throws IOException, ClassNotFoundException, TemplateException {
         Arguments arguments = new Arguments();
         new JCommander(arguments, args);
+        Utils.addTemplateValue(DocumentationRestApi.MOUNT_TEMPLATE, arguments.mountTemplateValue);
+        Utils.addTemplateValue(DocumentationRestApi.ID_TEMPLATE, arguments.idTemplateValue);
+        Utils.addTemplateValue(DocumentationRestApi.TITLE_TEMPLATE, arguments.titleTemplateValue);
+        Utils.addTemplateValue(DocumentationRestApi.VERSION_TEMPLATE, arguments.versionTemplateValue);
 
         List<RestDocumentation> docs = new LinkedList<RestDocumentation>();
         for (String input : arguments.inputs) {
@@ -251,5 +255,17 @@ public class RestDocAssembler {
         
         @Parameter(names = { "-s", "--scope" }, description = "Publication scope for output (e.g. public, private, etc) or \"all\"")
         String scope = "all";
+
+        @Parameter(names = { "--template-mount" }, description = "Mount point to use when filling templates.")
+        String mountTemplateValue = "";
+
+        @Parameter(names = { "--template-id" }, description = "Id to use when filling templates.")
+        String  idTemplateValue = "";
+
+        @Parameter(names = { "--template-title" }, description = "Title to use when filling templates.")
+        String  titleTemplateValue = "";
+
+        @Parameter(names = { "--template-version" }, description = "Version to use when filling templates.")
+        String  versionTemplateValue = "";
     }
 }

--- a/src/main/java/org/versly/rest/wsdoc/impl/RestDocumentation.java
+++ b/src/main/java/org/versly/rest/wsdoc/impl/RestDocumentation.java
@@ -17,13 +17,16 @@
 package org.versly.rest.wsdoc.impl;
 
 import org.apache.commons.lang3.StringUtils;
+import org.versly.rest.wsdoc.DocumentationRestApi;
 
 import java.io.*;
 import java.util.*;
 import java.util.regex.Pattern;
 
 public class RestDocumentation implements Serializable {
+    private static final long serialVersionUID = -3416760457544073264L;
     public static final String DEFAULT_API = "default";
+
     private Map<String, RestApi> _apis = new LinkedHashMap();
 
     public RestApi getRestApi(String apiBaseUrl) {
@@ -35,7 +38,7 @@ public class RestDocumentation implements Serializable {
     public Collection<RestApi> getApis() {
         return _apis.values();
     }
-    
+
     /**
      * Read and return a serialized {@link RestDocumentation} instance from <code>in</code>,
      * as serialized by {@link #toStream}.
@@ -84,6 +87,7 @@ public class RestDocumentation implements Serializable {
     }
     
     public class RestApi implements Serializable {
+        private static final long serialVersionUID = 5665219205108618731L;
         public static final String DEFAULT_IDENTIFIER = "(default)";
         
         private Map<String, Resource> _resources = new LinkedHashMap();
@@ -96,6 +100,14 @@ public class RestDocumentation implements Serializable {
 
         public RestApi(String identifier) {
             _identifier = identifier;
+        }
+
+        public Object readResolve() throws ObjectStreamException {
+            _identifier = Utils.fillTemplate(_identifier);
+            _apiMount = Utils.fillTemplate(_apiMount);
+            _apiTitle = Utils.fillTemplate(_apiTitle);
+            _apiVersion = Utils.fillTemplate(_apiVersion);
+            return this;
         }
 
         public String getIdentifier() {
@@ -218,6 +230,7 @@ public class RestDocumentation implements Serializable {
         }
         
         public class Resource implements Serializable {
+            private static final long serialVersionUID = -3436348850301436626L;
 
             private String path;
             private Map<String, Method> _methods = new LinkedHashMap();
@@ -272,6 +285,11 @@ public class RestDocumentation implements Serializable {
                     aggregateUrlFields.getFields().putAll(fields.getFields());
                 }
                 return aggregateUrlFields;
+            }
+
+            private Object readResolve() throws ObjectStreamException {
+                path = Utils.fillTemplate(path);
+                return this;
             }
 
             public class Method implements Serializable {

--- a/src/main/java/org/versly/rest/wsdoc/impl/Utils.java
+++ b/src/main/java/org/versly/rest/wsdoc/impl/Utils.java
@@ -16,8 +16,14 @@
 
 package org.versly.rest.wsdoc.impl;
 
+import org.versly.rest.wsdoc.DocumentationRestApi;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class Utils {
     public static final String SERIALIZED_RESOURCE_LOCATION = "org.versly.rest.wsdoc.web-service-api.ser";
+    private static Map<String,String> templateStrings = new HashMap<String, String>();
 
     public static String joinPaths(String lhs, String rhs) {
         // Mike Rawlins 2013-03-15 Don't append slash if right hand side is empty
@@ -36,5 +42,26 @@ public class Utils {
             rhs = rhs.substring(0, rhs.length() - 1);
 
         return lhs + "/" + rhs;
+    }
+
+    public static void addTemplateValue(String key, String value) {
+        templateStrings.put(key, value);
+    }
+
+    private static String getTemplateValue(String key) {
+        String value = templateStrings.get(key);
+        return value != null ? value : "";
+    }
+
+    public static String fillTemplate(String value) {
+        if (value == null) return value;
+        return value.replace(DocumentationRestApi.MOUNT_TEMPLATE,
+                getTemplateValue(DocumentationRestApi.MOUNT_TEMPLATE))
+                .replace(DocumentationRestApi.ID_TEMPLATE,
+                        getTemplateValue(DocumentationRestApi.ID_TEMPLATE))
+                .replace(DocumentationRestApi.TITLE_TEMPLATE,
+                        getTemplateValue(DocumentationRestApi.TITLE_TEMPLATE))
+                .replace(DocumentationRestApi.VERSION_TEMPLATE,
+                        getTemplateValue(DocumentationRestApi.VERSION_TEMPLATE));
     }
 }

--- a/src/test/java/org/versly/rest/wsdoc/AbstractRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/AbstractRestAnnotationProcessorTest.java
@@ -502,5 +502,23 @@ public abstract class AbstractRestAnnotationProcessorTest {
         AssertJUnit.assertTrue("RAML twoscope secref parameters does not include two_scope_service:admin scope", scopes.contains("two_scope_service:admin"));
     }
 
+    @Test
+    public void docTemplate() {
+        String mountPoint = "/foo";
+        Utils.addTemplateValue(DocumentationRestApi.ID_TEMPLATE, "fooID");
+        Utils.addTemplateValue(DocumentationRestApi.MOUNT_TEMPLATE, mountPoint);
+        processResource("ApiLevelTemplateDocs.java", "raml", "all");
+        Map.Entry<String, String> entry = output.entrySet().iterator().next();
+                entry.getKey();
+        AssertJUnit.assertTrue("expected file named AuthorizationScopes.raml",
+                entry.getKey().endsWith("ApiLevelTemplateDocs-fooID.raml"));
+        Raml raml = new RamlDocumentBuilder().build(entry.getValue(), "http://example.com");
+        AssertJUnit.assertNotNull("RAML not parseable", raml);
+        List<DocumentationItem> documentation = raml.getDocumentation();
+        AssertJUnit.assertEquals("RAML baseUri is incorrect", mountPoint, raml.getBaseUri());
+        Resource resource = raml.getResource(mountPoint);
+        AssertJUnit.assertNotNull("Cannot find resource related to:" + mountPoint, resource);
+    }
+
     protected abstract String getPackageToTest();
 }

--- a/src/test/resources/org/versly/rest/wsdoc/jaxrs/ApiLevelTemplateDocs.java
+++ b/src/test/resources/org/versly/rest/wsdoc/jaxrs/ApiLevelTemplateDocs.java
@@ -1,0 +1,28 @@
+package org.versly.rest.wsdoc.jaxrs;
+
+import org.versly.rest.wsdoc.DocumentationScope;
+import org.versly.rest.wsdoc.DocumentationRestApi;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.GET;
+
+/**
+ * Some documentation of the API itself.
+ */
+@DocumentationRestApi(
+        id = DocumentationRestApi.ID_TEMPLATE,
+        title = "The Ultimate REST API",
+        version = "v1",
+        mount = DocumentationRestApi.MOUNT_TEMPLATE)
+@DocumentationScope("public")
+public class ApiLevelTemplateDocs {
+
+    /**
+     * Some description of the widgets.
+     * @param id The widget identifier.
+     */
+    @GET
+    @Path("/widgets")
+    public void getWidget() {
+    }
+}

--- a/src/test/resources/org/versly/rest/wsdoc/springmvc/ApiLevelTemplateDocs.java
+++ b/src/test/resources/org/versly/rest/wsdoc/springmvc/ApiLevelTemplateDocs.java
@@ -1,0 +1,25 @@
+package org.versly.rest.wsdoc.springmvc;
+
+import org.springframework.web.bind.annotation.*;
+import org.versly.rest.wsdoc.DocumentationScope;
+import org.versly.rest.wsdoc.DocumentationRestApi;
+
+/**
+ * Some documentation of the API itself.
+ */
+@DocumentationRestApi(
+        id = DocumentationRestApi.ID_TEMPLATE,
+        title = "The Ultimate REST API",
+        version = "v1",
+        mount = DocumentationRestApi.MOUNT_TEMPLATE)
+@DocumentationScope("public")
+public class ApiLevelTemplateDocs {
+
+    /**
+     * Some description of the widgets.
+     * @param id The widget identifier.
+     */
+    @RequestMapping(value = "/widgets", method = RequestMethod.GET)
+    public void getWidget() {
+    }
+}


### PR DESCRIPTION
  Consider the case where classes A and B are
  controller classes defining end-points and
  'B extends A'. If A and B are in different
  modules, the mount-point for endpoints in A is
  not known before hand. When B is built, the
  end-points of A should use the same mount-point
  as B.

  For cases like this, this change adds support
  for templatizing the mount-points. When user
  runs the RestDocAssembler, he will pass in the
  optional --template-mount argument whose value
  is used to replace the template variable.

Signed-off-by: Prasanth Pallamreddy 