### PR TITLE
Added support for documenting methods with no @Path annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target
 *.ipr
 *.iws
 .idea
+.classpath
+.project
+.settings/

--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -58,7 +58,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 //   - MethodNameResolver
 //   - plural RequestMapping value support (i.e., two paths bound to one method)
 //   - support for methods not marked with @RequestMapping whose class does have a @RequestMapping annotation
-@SupportedAnnotationTypes({"org.springframework.web.bind.annotation.RequestMapping", "javax.ws.rs.Path"})
+@SupportedAnnotationTypes({"org.springframework.web.bind.annotation.RequestMapping", "javax.ws.rs.Path", "javax.ws.rs.GET", "javax.ws.rs.PUT", "javax.ws.rs.POST", "javax.ws.rs.DELETE"})
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class AnnotationProcessor extends AbstractProcessor {
 
@@ -119,11 +119,13 @@ public class AnnotationProcessor extends AbstractProcessor {
                                  Collection<String> processedPackageNames,
                                  RestImplementationSupport implementationSupport) {
 
-    	for (Element e : roundEnvironment.getElementsAnnotatedWith(implementationSupport.getMappingAnnotationType())) {
+        for (Class<? extends Annotation> a : implementationSupport.getMappingAnnotationTypes()) {
+            for (Element e : roundEnvironment.getElementsAnnotatedWith(a)) {
 
-        	if (e instanceof ExecutableElement) {
-        		addPackageName(processedPackageNames, e);
-                processRequestMappingMethod((ExecutableElement) e, implementationSupport);
+                if (e instanceof ExecutableElement) {
+                    addPackageName(processedPackageNames, e);
+                    processRequestMappingMethod((ExecutableElement) e, implementationSupport);
+                }
             }
         }
     }
@@ -738,7 +740,7 @@ public class AnnotationProcessor extends AbstractProcessor {
     }
 
     public interface RestImplementationSupport {
-        Class<? extends Annotation> getMappingAnnotationType();
+        ArrayList<Class<? extends Annotation>> getMappingAnnotationTypes();
 
         String[] getRequestPaths(ExecutableElement executableElement, TypeElement contextClass);
 

--- a/src/main/java/org/versly/rest/wsdoc/impl/JaxRSRestImplementationSupport.java
+++ b/src/main/java/org/versly/rest/wsdoc/impl/JaxRSRestImplementationSupport.java
@@ -4,6 +4,7 @@ import org.versly.rest.wsdoc.AnnotationProcessor;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.lang.model.element.ExecutableElement;
@@ -19,17 +20,23 @@ import javax.ws.rs.QueryParam;
 
 public class JaxRSRestImplementationSupport implements AnnotationProcessor.RestImplementationSupport {
     @Override
-    public Class<? extends Annotation> getMappingAnnotationType() {
-        return Path.class;
+    public ArrayList<Class<? extends Annotation>> getMappingAnnotationTypes() {
+        return new ArrayList<Class<? extends Annotation>>(Arrays.asList(Path.class, GET.class, PUT.class, POST.class, DELETE.class));
     }
 
     @Override
     public String[] getRequestPaths(ExecutableElement executableElement, TypeElement contextClass) {
         Path anno = executableElement.getAnnotation(Path.class);
         if (anno == null)
-            throw new IllegalStateException(String.format(
+            if(executableElement.getAnnotation(GET.class) == null &&
+                executableElement.getAnnotation(PUT.class) == null &&
+                executableElement.getAnnotation(POST.class) == null &&
+                executableElement.getAnnotation(DELETE.class) == null)
+                throw new IllegalStateException(String.format(
                     "The Path annotation for %s.%s is not parseable. Exactly one value is required.",
                     contextClass.getQualifiedName(), executableElement.getSimpleName()));
+            else
+                return new String[] { "" };
         else
             return new String[] { anno.value() };
     }

--- a/src/main/java/org/versly/rest/wsdoc/impl/SpringMVCRestImplementationSupport.java
+++ b/src/main/java/org/versly/rest/wsdoc/impl/SpringMVCRestImplementationSupport.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.versly.rest.wsdoc.AnnotationProcessor;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -14,8 +16,8 @@ import javax.lang.model.element.VariableElement;
 public class SpringMVCRestImplementationSupport implements AnnotationProcessor.RestImplementationSupport {
 
     @Override
-    public Class<? extends Annotation> getMappingAnnotationType() {
-        return RequestMapping.class;
+    public ArrayList<Class<? extends Annotation>> getMappingAnnotationTypes() {
+        return new ArrayList<Class<? extends Annotation>>(Arrays.asList(RequestMapping.class));
     }
 
     @Override


### PR DESCRIPTION
Previously, an API like such would not be picked up by the JAXRS processor.
```
@Path("/snow-report/{mountainId}")
public class SnowReportController {
    @GET
    public SnowReport getReportForMountain(
        @PathParam("mountainId") String mountainId) {
        return null;
    }
}
```
Now it does.

