### PR TITLE
Added support for JAXRS method level documentation.

### DIFF
--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -58,7 +58,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 //   - MethodNameResolver
 //   - plural RequestMapping value support (i.e., two paths bound to one method)
 //   - support for methods not marked with @RequestMapping whose class does have a @RequestMapping annotation
-@SupportedAnnotationTypes({"org.springframework.web.bind.annotation.RequestMapping", "javax.ws.rs.Path"})
+@SupportedAnnotationTypes({"org.springframework.web.bind.annotation.RequestMapping", "javax.ws.rs.Path", "javax.ws.rs.GET", "javax.ws.rs.PUT", "javax.ws.rs.POST", "javax.ws.rs.DELETE", "javax.ws.rs.HEAD", "javax.ws.rs.OPTIONS"})
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class AnnotationProcessor extends AbstractProcessor {
 
@@ -119,11 +119,13 @@ public class AnnotationProcessor extends AbstractProcessor {
                                  Collection<String> processedPackageNames,
                                  RestImplementationSupport implementationSupport) {
 
-    	for (Element e : roundEnvironment.getElementsAnnotatedWith(implementationSupport.getMappingAnnotationType())) {
+        for (Class<? extends Annotation> a : implementationSupport.getExtendedMappingAnnotationTypes()) {
+            for (Element e : roundEnvironment.getElementsAnnotatedWith(a)) {
 
-        	if (e instanceof ExecutableElement) {
-        		addPackageName(processedPackageNames, e);
-                processRequestMappingMethod((ExecutableElement) e, implementationSupport);
+                if (e instanceof ExecutableElement) {
+                    addPackageName(processedPackageNames, e);
+                    processRequestMappingMethod((ExecutableElement) e, implementationSupport);
+                }
             }
         }
     }
@@ -739,6 +741,8 @@ public class AnnotationProcessor extends AbstractProcessor {
 
     public interface RestImplementationSupport {
         Class<? extends Annotation> getMappingAnnotationType();
+
+        Set<Class<? extends Annotation>> getExtendedMappingAnnotationTypes();
 
         String[] getRequestPaths(ExecutableElement executableElement, TypeElement contextClass);
 

--- a/src/main/java/org/versly/rest/wsdoc/impl/SpringMVCRestImplementationSupport.java
+++ b/src/main/java/org/versly/rest/wsdoc/impl/SpringMVCRestImplementationSupport.java
@@ -6,6 +6,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.versly.rest.wsdoc.AnnotationProcessor;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -16,6 +19,11 @@ public class SpringMVCRestImplementationSupport implements AnnotationProcessor.R
     @Override
     public Class<? extends Annotation> getMappingAnnotationType() {
         return RequestMapping.class;
+    }
+
+    @Override
+    public Set<Class<? extends Annotation>> getExtendedMappingAnnotationTypes() {
+        return new HashSet<Class<? extends Annotation>>(Arrays.asList(RequestMapping.class));
     }
 
     @Override

--- a/src/test/java/org/versly/rest/wsdoc/AbstractRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/AbstractRestAnnotationProcessorTest.java
@@ -73,6 +73,7 @@ public abstract class AbstractRestAnnotationProcessorTest {
             for (String line = null; (line = reader.readLine()) != null; ) {
                 fileContent += line + "\n";
             }
+            reader.close();
             output.put(fileWritten, fileContent);
             if (fileWritten.equals(outputFile)) {
                 defaultApiOutput = fileContent;
@@ -196,6 +197,12 @@ public abstract class AbstractRestAnnotationProcessorTest {
             AssertJUnit.assertTrue(
                     "expected 'allMethodsDelete' in doc string; got: \n" + defaultApiOutput,
                     defaultApiOutput.contains("allMethodsDelete"));
+            AssertJUnit.assertTrue(
+                    "expected 'allMethodsHead' in doc string; got: \n" + defaultApiOutput,
+                    defaultApiOutput.contains("allMethodsHead"));
+            AssertJUnit.assertTrue(
+                    "expected 'allMethodsOptions' in doc string; got: \n" + defaultApiOutput,
+                    defaultApiOutput.contains("allMethodsOptions"));
         }
     }
 

--- a/src/test/java/org/versly/rest/wsdoc/JaxRSRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/JaxRSRestAnnotationProcessorTest.java
@@ -33,6 +33,41 @@ public class JaxRSRestAnnotationProcessorTest extends AbstractRestAnnotationProc
     }
 
     @Test
+    public void assertClassPathOnly() {
+        for (String format : _outputFormats) {
+            processResource("ClassPathOnly.java", format, "all");
+            AssertJUnit.assertTrue(
+                    "expected 'classPathOnly' in doc string; got: \n" + defaultApiOutput,
+                    defaultApiOutput.contains("classPathOnly"));
+            if (format.equals("html")) {
+                AssertJUnit.assertTrue(
+                        "expected 'classPathOnly_GET' in doc string; got: \n" + defaultApiOutput,
+                        defaultApiOutput.contains("classPathOnly_GET"));
+            }
+        }
+    }
+
+    @Test
+    public void assertNoPath() {
+        for (String format : _outputFormats) {
+            processResource("NoPath.java", format, "all");
+            if (format.equals("html")) {
+                AssertJUnit.assertTrue(
+                        "expected '_GET' in doc string; got: \n" + defaultApiOutput,
+                        defaultApiOutput.contains("_GET"));
+            }
+            if (format.equals("raml")) {
+                AssertJUnit.assertTrue(
+                        "expected 'baseUri: /' in doc string; got: \n" + defaultApiOutput,
+                        defaultApiOutput.contains("baseUri: /"));
+                AssertJUnit.assertTrue(
+                        "expected 'get:' in doc string; got: \n" + defaultApiOutput,
+                        defaultApiOutput.contains("get:"));
+            }
+        }
+    }
+
+    @Test
     public void assertRequestBody() {
         processResource("PostWithRequestBody.java", "html", "all");
 

--- a/src/test/java/org/versly/rest/wsdoc/SpringMVCRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/SpringMVCRestAnnotationProcessorTest.java
@@ -17,19 +17,13 @@
 package org.versly.rest.wsdoc;
 
 import freemarker.template.TemplateException;
-import org.raml.model.*;
-import org.raml.parser.visitor.RamlDocumentBuilder;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.versly.rest.wsdoc.impl.RestDocumentation;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 public class SpringMVCRestAnnotationProcessorTest extends AbstractRestAnnotationProcessorTest {
 

--- a/src/test/resources/org/versly/rest/wsdoc/jaxrs/AllMethods.java
+++ b/src/test/resources/org/versly/rest/wsdoc/jaxrs/AllMethods.java
@@ -2,6 +2,8 @@ package org.versly.rest.wsdoc.jaxrs;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.DELETE;
@@ -26,5 +28,15 @@ public class AllMethods {
     @DELETE
     @Path("allMethodsDelete")
     public void allMethodsDelete() {
+    }
+
+    @HEAD
+    @Path("allMethodsHead")
+    public void allMethodsHead() {
+    }
+
+    @OPTIONS
+    @Path("allMethodsOptions")
+    public void allMethodsOptions() {
     }
 }

--- a/src/test/resources/org/versly/rest/wsdoc/jaxrs/ClassPathOnly.java
+++ b/src/test/resources/org/versly/rest/wsdoc/jaxrs/ClassPathOnly.java
@@ -1,0 +1,12 @@
+package org.versly.rest.wsdoc.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("classPathOnly")
+public class ClassPathOnly {
+
+    @GET
+    public void classPathOnlyGet() {
+    }
+}

--- a/src/test/resources/org/versly/rest/wsdoc/jaxrs/NoPath.java
+++ b/src/test/resources/org/versly/rest/wsdoc/jaxrs/NoPath.java
@@ -1,0 +1,10 @@
+package org.versly.rest.wsdoc.jaxrs;
+
+import javax.ws.rs.GET;
+
+public class NoPath {
+
+    @GET
+    public void noPathGet() {
+    }
+}

--- a/src/test/resources/org/versly/rest/wsdoc/springmvc/AllMethods.java
+++ b/src/test/resources/org/versly/rest/wsdoc/springmvc/AllMethods.java
@@ -21,6 +21,14 @@ public class AllMethods {
     public void allMethodsDelete() {
     }
 
+    @RequestMapping(value = "/allMethodsHead", method = RequestMethod.HEAD)
+    public void allMethodsHead() {
+    }
+
+    @RequestMapping(value = "/allMethodsOptions", method = RequestMethod.OPTIONS)
+    public void allMethodsOptions() {
+    }
+
     @RequestMapping(value = "/allMethodsPatch", method = RequestMethod.PATCH)
     public void allMethodsPatch() {
     }


### PR DESCRIPTION
Added support for JAXRS method level documentation without relying on [versly-wsdoc] custom annotations. (@DocumentationRestApi)