### PR TITLE
Added support for method-level composed annotation introduced starting Spring Framework v4.3

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-jdk8:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: "[mvn -B clean verify -U]"
+      run: mvn -B clean verify -U
+  build-jdk11:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: '11.0.2+9'
+    - name: "[mvn -B clean verify -U]"
+      run: mvn -B clean verify -U
+  

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Note, with release 1.1-SNAPSHOT, wsdoc requires a Java 8 runtime at annotations 
 <a id="limitations"/>
 #### Limitations
 
-* wsdoc is currently limited to REST endpoints identified via [Spring 3 web bind annotations](http://blog.springsource.com/2009/03/08/rest-in-spring-3-mvc/) or [JaxRs endpoints](https://github.com/eclipse-ee4j/jaxrs-api) (@RequestMapping and @Path).
-
+* wsdoc is currently limited to REST endpoints identified via [Spring 4.3 web bind annotations](https://docs.spring.io/spring-framework/docs/4.3.0.RELEASE/spring-framework-reference/htmlsingle/#mvc-ann-requestmapping) or [JaxRs endpoints](https://github.com/eclipse-ee4j/jaxrs-api) (@RequestMapping, @GetMapping, @PostMapping, @PutMapping, @PatchMapping, @DeleteMapping, and @Path).
+  
 * wsdoc needs access to your sources to extract JavaDoc comments. If you package your DTOs in a separate compilation unit than your controllers using a build tool like mvn, the sources for those compilation units might not be available. So, wsdoc will not find the comments and will therefore not include them in the generated output. This can be resolved by providing additional source locations to apt.
 
 * We've made a bunch of JSON-related assumptions about how you want your DTOs to be represented. None of the Jackson annotations (except @JsonIgnore) are considered, so you're pretty much left with a simple bean transformation.

--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -81,7 +81,7 @@ import org.versly.rest.wsdoc.impl.JsonPrimitive;
 import org.versly.rest.wsdoc.impl.JsonRecursiveObject;
 import org.versly.rest.wsdoc.impl.JsonType;
 import org.versly.rest.wsdoc.impl.RestDocumentation;
-import org.versly.rest.wsdoc.impl.SpringMVCRestImplementationSupport;
+import org.versly.rest.wsdoc.impl.SpringMVC43RestImplementationSupport;
 import org.versly.rest.wsdoc.impl.Utils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -102,7 +102,10 @@ import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
 //   - MethodNameResolver
 //   - plural RequestMapping value support (i.e., two paths bound to one method)
 //   - support for methods not marked with @RequestMapping whose class does have a @RequestMapping annotation
-@SupportedAnnotationTypes({"org.springframework.web.bind.annotation.RequestMapping", "javax.ws.rs.Path", "javax.ws.rs.GET", "javax.ws.rs.PUT", "javax.ws.rs.POST", "javax.ws.rs.DELETE", "javax.ws.rs.HEAD", "javax.ws.rs.OPTIONS"})
+@SupportedAnnotationTypes({"org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.GetMapping",
+                           "org.springframework.web.bind.annotation.PostMapping", "org.springframework.web.bind.annotation.PatchMapping",
+                           "org.springframework.web.bind.annotation.DeleteMapping", "org.springframework.web.bind.annotation.PutMapping",
+                           "javax.ws.rs.Path", "javax.ws.rs.GET", "javax.ws.rs.PUT", "javax.ws.rs.POST", "javax.ws.rs.DELETE", "javax.ws.rs.HEAD", "javax.ws.rs.OPTIONS"})
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class AnnotationProcessor extends AbstractProcessor {
 
@@ -128,8 +131,8 @@ public class AnnotationProcessor extends AbstractProcessor {
             return true;
 
         Collection<String> processedPackageNames = new LinkedHashSet<String>();
-        processElements(roundEnvironment, processedPackageNames, new SpringMVCRestImplementationSupport());
         processElements(roundEnvironment, processedPackageNames, new JaxRSRestImplementationSupport());
+        processElements(roundEnvironment, processedPackageNames, new SpringMVC43RestImplementationSupport());
         _docs.postProcess();
 
         if (_docs.getApis().size() > 0) {

--- a/src/main/java/org/versly/rest/wsdoc/impl/SpringMVC43RestImplementationSupport.java
+++ b/src/main/java/org/versly/rest/wsdoc/impl/SpringMVC43RestImplementationSupport.java
@@ -1,0 +1,169 @@
+package org.versly.rest.wsdoc.impl;
+
+import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.PATCH;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+import static org.springframework.web.bind.annotation.RequestMethod.PUT;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Implements support for method-level composed-variants for
+ * {@link org.springframework.web.bind.annotation.RequestMapping} annotation introduced since Spring Framework 4.3.
+ *
+ * @author Sidharth Mishra
+ * @see <a href="https://docs.spring.io/spring-framework/docs/4.3.1.RELEASE/spring-framework-reference/htmlsingle/#mvc-ann-requestmapping-composed">mvc-ann-requestmapping-composed</a>
+ */
+public class SpringMVC43RestImplementationSupport extends SpringMVCRestImplementationSupport {
+
+    /** The new method-level composed annotations introduced since Spring Framework 4.3. */
+    private Set<Class<? extends Annotation>> getSpring43ComposedAnnotationTypes() {
+
+        return new HashSet<>(Arrays.asList(GetMapping.class, PostMapping.class, PutMapping.class, PatchMapping.class, DeleteMapping.class));
+    }
+    
+    /**
+     * Gets the path-value for the supported annotations.
+     *
+     * @param annotation the method-level composed annotations from Spring Framework 4.3+
+     * @return the request-paths if the annotation is supported, else {@link Optional#empty()}.
+     */
+    private Optional<String[]> getRequestPathsFromAnnotation(Annotation annotation) {
+
+        if (annotation instanceof GetMapping) {
+
+            return Optional.of(((GetMapping) annotation).value());
+        } else if (annotation instanceof PostMapping) {
+
+            return Optional.of(((PostMapping) annotation).value());
+        } else if (annotation instanceof PutMapping) {
+
+            return Optional.of(((PutMapping) annotation).value());
+        } else if (annotation instanceof PatchMapping) {
+
+            return Optional.of(((PatchMapping) annotation).value());
+        } else if (annotation instanceof DeleteMapping) {
+
+            return Optional.of(((DeleteMapping) annotation).value());
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the HTTP-method name for the supported annotation.
+     *
+     * @param annotation the spring-mvc annotation,
+     * @return the HTTP-method name for the annotation if supported, else {@link Optional#empty()}.
+     */
+    private Optional<String> getRequestMethod(Annotation annotation) {
+
+        if (annotation instanceof GetMapping) {
+
+            return Optional.of(GET.name());
+        } else if (annotation instanceof PostMapping) {
+
+            return Optional.of(POST.name());
+        } else if (annotation instanceof PutMapping) {
+
+            return Optional.of(PUT.name());
+        } else if (annotation instanceof PatchMapping) {
+
+            return Optional.of(PATCH.name());
+        } else if (annotation instanceof DeleteMapping) {
+
+            return Optional.of(DELETE.name());
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Gets the request-paths for the supported Spring MVC method-level annotations.
+     * Starts with the newer method-level composed annotations introduced since Spring Framework 4.3. If it cannot find any new annotations, delegates the control to super-class
+     * for handling {@link RequestMapping} annotation.
+     *
+     * @param annotationProvider a function that searches for the annotation of the annotationClass' type on the element under process.
+     * @param altSupplier        the supplier to use in-case the annotation is {@link RequestMapping} –– to be delegated to the super-class,
+     * @return the request-paths from supported annotations, else an empty-string-array.
+     */
+    private String[] getRequestPaths(Function<Class<? extends Annotation>, Annotation> annotationProvider, Supplier<String[]> altSupplier) {
+
+        for (Class<? extends Annotation> annotationClass : this.getSpring43ComposedAnnotationTypes()) {
+
+            Annotation annotation = annotationProvider.apply(annotationClass);
+
+            if (Objects.nonNull(annotation)) {
+
+                Optional<String[]> requestPaths = getRequestPathsFromAnnotation(annotation);
+
+                if (requestPaths.isPresent()) {
+
+                    return requestPaths.get();
+                }
+            }
+        }
+        // Delegate the request-path computation for the RequestMapping annotated methods to super-class
+        //
+        return altSupplier.get();
+    }
+
+    /** Supports {@link RequestMapping} and the new method-level composed annotations introduced in Spring Framework 4.3. */
+    @Override
+    public Set<Class<? extends Annotation>> getExtendedMappingAnnotationTypes() {
+
+        Set<Class<? extends Annotation>> supportedAnnotationTypes = new HashSet<>(Collections.singletonList(RequestMapping.class));
+
+        supportedAnnotationTypes.addAll(this.getSpring43ComposedAnnotationTypes());
+
+        return supportedAnnotationTypes;
+    }
+
+    @Override
+    public String[] getRequestPaths(ExecutableElement executableElement, TypeElement contextClass) {
+
+        return getRequestPaths(executableElement::getAnnotation, () -> super.getRequestPaths(executableElement, contextClass));
+    }
+
+    @Override
+    public String[] getRequestPaths(TypeElement cls) {
+
+        return getRequestPaths(cls::getAnnotation, () -> super.getRequestPaths(cls));
+    }
+
+    @Override
+    public String getRequestMethod(ExecutableElement executableElement, TypeElement contextClass) {
+
+        for (Class<? extends Annotation> annotationClass : this.getSpring43ComposedAnnotationTypes()) {
+
+            Optional<String> requestMethod = getRequestMethod(executableElement.getAnnotation(annotationClass));
+
+            if (requestMethod.isPresent()) {
+
+                return requestMethod.get();
+            }
+        }
+        // Delegate to super-class to handle the RequestMapping annotation
+        //
+        return super.getRequestMethod(executableElement, contextClass);
+    }
+}

--- a/src/test/java/org/versly/rest/wsdoc/SpringMVCRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/SpringMVCRestAnnotationProcessorTest.java
@@ -109,6 +109,33 @@ public class SpringMVCRestAnnotationProcessorTest extends AbstractRestAnnotation
                 defaultApiOutput.contains(">childField<"));
     }
 
+    @Test
+    public void assertSpring43ComposedAnnotationController() {
+
+        super.assertAllMethods();
+
+        for (String format : _outputFormats) {
+
+            processResource("Spring43ComposedAnnotationController.java", format, "all");
+
+            AssertJUnit.assertTrue(
+                "expected 'theGetMethod' in doc string; got: \n" + defaultApiOutput,
+                defaultApiOutput.contains("theGetMethod"));
+            AssertJUnit.assertTrue(
+                "expected 'thePostMethod' in doc string; got: \n" + defaultApiOutput,
+                defaultApiOutput.contains("thePostMethod"));
+            AssertJUnit.assertTrue(
+                "expected 'thePutMethod' in doc string; got: \n" + defaultApiOutput,
+                defaultApiOutput.contains("thePutMethod"));
+            AssertJUnit.assertTrue(
+                "expected 'theDeleteMethod' in doc string; got: \n" + defaultApiOutput,
+                defaultApiOutput.contains("theDeleteMethod"));
+            AssertJUnit.assertTrue(
+                "expected 'thePatchMethod' in doc string; got: \n" + defaultApiOutput,
+                defaultApiOutput.contains("thePatchMethod"));
+        }
+    }
+
     public static void main(String[] args) throws IOException, URISyntaxException {
         File dir = new File(args[0]);
         for (int i = 1; i < args.length; i++) {

--- a/src/test/resources/org/versly/rest/wsdoc/springmvc/Spring43ComposedAnnotationController.java
+++ b/src/test/resources/org/versly/rest/wsdoc/springmvc/Spring43ComposedAnnotationController.java
@@ -1,0 +1,97 @@
+package org.versly.rest.wsdoc.springmvc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Tests the new method-level composed variants of the @{@link org.springframework.web.bind.annotation.RequestMapping} annotations introduced in
+ * Spring Framework 4.3.
+ * <p>
+ * This tests the following annotations:
+ * <ul>
+ *     <li>{@link GetMapping}</li>
+ *     <li>{@link PostMapping}</li>
+ *     <li>{@link PutMapping}</li>
+ *     <li>{@link DeleteMapping}</li>
+ *     <li>{@link PatchMapping}</li>
+ * </ul>
+ *
+ * @author Sidharth Mishra
+ * @see https://docs.spring.io/spring-framework/docs/4.3.1.RELEASE/spring-framework-reference/htmlsingle/#mvc-ann-requestmapping-composed
+ */
+public class Spring43ComposedAnnotationController {
+
+    /**
+     * Some description for this GET method.
+     *
+     * @param id      The ID.
+     * @param pageNbr The page number.
+     * @return some map from string to string.
+     */
+    @GetMapping("/theGetMethod")
+    public Map<String, String> theGetMethod(@RequestParam("id") UUID id, @RequestParam("pageNbr") int pageNbr) {
+
+        return new HashMap<>();
+    }
+
+    /**
+     * Some description for this POST method.
+     *
+     * @param theReqBody the request-body.
+     * @return the ID of item created.
+     */
+    @PostMapping("/thePostMethod")
+    public UUID thePostMethod(@RequestBody Map<String, String> theReqBody) {
+
+        return null;
+    }
+
+    /**
+     * Some description for this PUT method.
+     *
+     * @param id                 The ID of the item to update.
+     * @param theReqBody         the request-body containing data to update.
+     * @param httpServletRequest the raw {@link HttpServletRequest} instance for more contextual data.
+     * @return the updated item's ID.
+     */
+    @PutMapping("/thePutMethod/{id}")
+    public UUID thePutMethod(@PathVariable("id") UUID id, @RequestBody Map<String, String> theReqBody, HttpServletRequest httpServletRequest) {
+
+        return null;
+    }
+
+    /**
+     * Some description for this DELETE method.
+     *
+     * @param id The ID of the item to delete.
+     */
+    @DeleteMapping("/theDeleteMethod/{id}")
+    public void theDeleteMethod(@PathVariable("id") UUID id) {
+
+    }
+
+    /**
+     * Some description for this PATCH method.
+     *
+     * @param id         The ID of the item to patch.
+     * @param theReqBody The request-body containing data to path.
+     * @return the ID of the item that was successfully patched.
+     */
+    @PatchMapping("/thePatchMethod/{id}")
+    public UUID thePatchMethod(@PathVariable("id") UUID id, @RequestBody Map<String, String> theReqBody) {
+
+        return null;
+    }
+}


### PR DESCRIPTION
This commit contains the following:

- Extended SpringMVCRestImplementationSupport to SpringMVC43RestImplementationSupport and provided support for the new method-level composed annotations introduced in Spring Framework v4.3: GetMapping, PostMapping, PutMapping, PatchMapping, and DeleteMapping.
- Added test and example-resource-class to verify the implementation.
- Updated the documentation's limitation section to point to Spring MVC 4.3.0+ instead of Spring MVC v3.x