### PR TITLE
Sanitize 1st parameter of Uri and fix a bug where URI parameters were removed because of a bug

### DIFF
--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -204,7 +204,18 @@ public class AnnotationProcessor extends AbstractProcessor {
 
                 // both spring and jersey permit colon delimited regexes in path annotations which are not compatible with RAML
                 // which expects resource identifiers to comply with RFC-6570 URI template semantics - so remove regex portion
-                fullPath = fullPath.replaceAll(":.*}", "}");
+                String[] splitedPath = fullPath.split("/");
+                if (splitedPath != null && splitedPath.length > 0) {
+                    for (int splitedPathIndex = 0; splitedPathIndex < splitedPath.length; splitedPathIndex++) {
+                        splitedPath[splitedPathIndex] = splitedPath[splitedPathIndex].replaceAll(":.*}", "}");
+                        if (splitedPathIndex==1 && splitedPath[splitedPathIndex] != null) {
+                            // According to RFC-6570 URI template semantics, 1st parameter cannot be a variable
+                            // Spring programs can have a variable as 1st parameter e.g. "${spring.application.name}/api/v1"
+                            splitedPath[splitedPathIndex] = splitedPath[splitedPathIndex].replaceAll("[{}]", "");
+                        }
+                    }
+                    fullPath = String.join("/", splitedPath);
+                }
 
                 // set documentation and metadata on api
                 RestDocumentation.RestApi api = null;

--- a/src/test/java/org/versly/rest/wsdoc/AbstractRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/AbstractRestAnnotationProcessorTest.java
@@ -300,6 +300,17 @@ public abstract class AbstractRestAnnotationProcessorTest {
     }
 
     @Test
+    public void assertUriFirstParameterValidation() {
+        processResource("UriFirstParameterValidation.java", "raml", "all");
+        Raml raml = new RamlDocumentBuilder().build(defaultApiOutput, "http://example.com");
+        AssertJUnit.assertNotNull("RAML not parseable", raml);
+        Resource resource = raml.getResource("/$base-service.server.api-path/api/v1/group/{id}/participant");
+        AssertJUnit.assertNotNull("Resource /$base-service.server.api-path/api/v1/group/{id}/participant", resource);
+        UriParameter id = resource.getUriParameters().get("id");
+        AssertJUnit.assertNotNull("Resource /$base-service.server.api-path/api/v1/group/{id}/participant has no id URI parameter", id);
+    }
+
+    @Test
     public void testEnumsTypesQueryForRaml() {
         processResource("RestDocEndpoint.java", "raml", "all");
         Raml raml = new RamlDocumentBuilder().build(defaultApiOutput, "http://example.com");

--- a/src/test/resources/org/versly/rest/wsdoc/jaxrs/UriFirstParameterValidation.java
+++ b/src/test/resources/org/versly/rest/wsdoc/jaxrs/UriFirstParameterValidation.java
@@ -1,0 +1,21 @@
+import org.springframework.web.bind.annotation.*;
+
+
+import java.net.URI;
+import java.util.UUID;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Path("${base-service.server.api-path:}/api/v1/")
+public class UriFirstParameterValidation {
+    /**
+     * Some description of the group.
+     * @param id The participant's parent identifier.
+     */
+    @GET
+    @Path("/group/{id}/participant")
+    public void getParticipant(@PathVariable("id") String id) {
+    }
+}

--- a/src/test/resources/org/versly/rest/wsdoc/springmvc/UriFirstParameterValidation.java
+++ b/src/test/resources/org/versly/rest/wsdoc/springmvc/UriFirstParameterValidation.java
@@ -1,0 +1,15 @@
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.UUID;
+
+@RequestMapping("${base-service.server.api-path:}/api/v1/")
+public class UriFirstParameterValidation {
+    /**
+     * Some description of the group.
+     * @param id The participant's parent identifier.
+     */
+    @RequestMapping(value = "/group/{id}/participant", method = RequestMethod.GET)
+    public void getParticipant(@PathVariable("id") String id) {
+    }
+}


### PR DESCRIPTION
I have tried to address 2 problems here.

1. The regex to remove colon-delimited regexes was removing all the intermediate path if there was another path variable. e.g. `/${base-service.server.api-path:}/api/v1/group/{id}/participant` was shortened to `/${base-service.server.api-path}/participant`. So I broke this path into individual paths and then applied regex

2. REST controllers can have a variable value as a parameter that is picked from application.yaml file. e.g. URI can be `/${base-service.server.api-path:}/api/v1/group/{id}/participant`. However, this variable will not be resolved while parsing the Controller file and RAML parsing will fail because the 1st parameter cannot be a path variable according to the RFC-6570 URI template.

We can check whether a URI is valid or not as per this regex - https://regex101.com/r/DstcXC/1/