### PR TITLE
Match Jackson's usage of treating Optional<T> as T

### DIFF
--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -604,6 +605,12 @@ public class AnnotationProcessor extends AbstractProcessor {
 
         @Override
         public JsonType visitDeclared(DeclaredType declaredType, Void o) {
+            // Transparently replace Optional<T> with T. This is specifically
+            // to support Jackson's Optional handling implemented in Jdk8Module.
+            if (isInstanceOf(declaredType, Optional.class)) {
+                TypeParameterElement elem = ((TypeElement) declaredType.asElement()).getTypeParameters().get(0);
+                return visit(elem.asType());
+            }
 
             if (_typeRecursionDetector.contains(declaredType.toString()))
                 return new JsonRecursiveObject(declaredType.asElement().getSimpleName().toString());

--- a/src/test/java/org/versly/rest/wsdoc/SpringMVCRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/SpringMVCRestAnnotationProcessorTest.java
@@ -83,6 +83,16 @@ public class SpringMVCRestAnnotationProcessorTest extends AbstractRestAnnotation
     }
 
     @Test
+    public void assertOptionalIsNotTraversedInto() {
+        processResource("RestDocEndpoint.java", "html", "all");
+        AssertJUnit.assertFalse(
+                "'present' field (member field of Optional class) should not be in results",
+                defaultApiOutput.contains("present"));
+        AssertJUnit.assertTrue(defaultApiOutput,
+                defaultApiOutput.contains("optionalfield"));
+    }
+
+    @Test
     public void assertAllMethods() {
         super.assertAllMethods();
         for (String format : _outputFormats) {

--- a/src/test/resources/org/versly/rest/wsdoc/springmvc/RestDocEndpoint.java
+++ b/src/test/resources/org/versly/rest/wsdoc/springmvc/RestDocEndpoint.java
@@ -67,6 +67,12 @@ public class RestDocEndpoint {
         return null;
     }
 
+    @RequestMapping(value="optional", method = RequestMethod.POST)
+    public void optionalFieldInRequestBody(HttpServletRequest req,
+                               @RequestBody ValueWithOptional optional)
+    {
+    }
+
     @RequestMapping(value="recursiveParam", method = RequestMethod.POST)
     public void recursiveParam(HttpServletRequest req,
                                @RequestParam("recursive") ValueWithRecursion recursive)
@@ -132,6 +138,18 @@ public class RestDocEndpoint {
         }
 
         public void setOther(ValueWithRecursion other) {
+        }
+    }
+
+    public class ValueWithOptional {
+        /**
+         * this field may be omitted!
+         */
+        public Optional<String> getOptionalfield() {
+            return null;
+        }
+
+        public void setOptionalfield(Optional<String> other) {
         }
     }
 


### PR DESCRIPTION
When using Jackson's Jdk8Module, fields that have a null value are
deserialized as Optional.empty(), whereas a field that is not provided
will simply be null. This allows REST endpoints to distinguish between
the user not providing a field vs providing a null value without needing
to implement special logic in the bean builder. This is especially
useful for PATCH requests that may want to allow for either setting a
field to null *or* leaving it at its current value by omitting the
field.

Prior to this commit, using this pattern would result in wsdoc
traversing the Optional class itself, which is not useful. This commit
causes Optional<T> to be simply treated as T, matching Jackson's
behavior.

The tests for this functionality are pattered after the tests for the
UUID type, which also has fields that should not be traversed.