### PR TITLE
Fix schema processing of Optional<T> fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
             <version>2.4.2</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.4.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>6.8.8</version>

--- a/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
+++ b/src/main/java/org/versly/rest/wsdoc/AnnotationProcessor.java
@@ -90,6 +90,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 /**
  * Generates an HTML documentation file describing the REST / JSON endpoints as defined with the
@@ -966,6 +967,7 @@ public class AnnotationProcessor extends AbstractProcessor {
                 ObjectMapper m = new ObjectMapper();
                 m.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
                 m.registerModule(new JodaModule());
+                m.registerModule(new Jdk8Module());
                 SchemaFactoryWrapper visitor = new SchemaFactoryWrapper();
                 m.acceptJsonFormatVisitor(m.constructType(dtoClass), visitor);
                 serializedSchema = m.writeValueAsString(visitor.finalSchema());

--- a/src/test/java/org/versly/rest/wsdoc/SpringMVCRestAnnotationProcessorTest.java
+++ b/src/test/java/org/versly/rest/wsdoc/SpringMVCRestAnnotationProcessorTest.java
@@ -84,10 +84,13 @@ public class SpringMVCRestAnnotationProcessorTest extends AbstractRestAnnotation
 
     @Test
     public void assertOptionalIsNotTraversedInto() {
-        processResource("RestDocEndpoint.java", "html", "all");
+        processResource("RestDocEndpoint.java", "raml", "all");
         AssertJUnit.assertFalse(
                 "'present' field (member field of Optional class) should not be in results",
                 defaultApiOutput.contains("present"));
+        AssertJUnit.assertFalse(
+                "'Optional<' should not be in results",
+                defaultApiOutput.contains("Optional<"));
         AssertJUnit.assertTrue(defaultApiOutput,
                 defaultApiOutput.contains("optionalfield"));
     }

--- a/src/test/java/org/versly/rest/wsdoc/model/ValueWithOptional.java
+++ b/src/test/java/org/versly/rest/wsdoc/model/ValueWithOptional.java
@@ -1,0 +1,15 @@
+package org.versly.rest.wsdoc.model;
+
+import java.util.Optional;
+
+public class ValueWithOptional {
+    /**
+     * this field may be omitted!
+     */
+    public Optional<String> getOptionalfield() {
+        return null;
+    }
+
+    public void setOptionalfield(Optional<String> other) {
+    }
+}

--- a/src/test/resources/org/versly/rest/wsdoc/springmvc/RestDocEndpoint.java
+++ b/src/test/resources/org/versly/rest/wsdoc/springmvc/RestDocEndpoint.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.versly.rest.wsdoc.RestApiMountPoint;
 import org.versly.rest.wsdoc.model.ParameterizedTypeReferrer;
+import org.versly.rest.wsdoc.model.ValueWithOptional;
 
 @RestApiMountPoint("/mount")
 @RequestMapping("/api/v1")
@@ -138,18 +139,6 @@ public class RestDocEndpoint {
         }
 
         public void setOther(ValueWithRecursion other) {
-        }
-    }
-
-    public class ValueWithOptional {
-        /**
-         * this field may be omitted!
-         */
-        public Optional<String> getOptionalfield() {
-            return null;
-        }
-
-        public void setOptionalfield(Optional<String> other) {
         }
     }
 


### PR DESCRIPTION
Although the HTML output of the tests was correct, the schema portion of
RAML output was not correct for Optional<T> fields, due to it using a
different code path that was not exercised by the tests. This commit
makes a few changes to rectify this:

 1. The test was modified to inspect the RAML output, with a more
    explicit check for the Optional type in the output.

 2. The test model was moved to a top-level class, since the schema
    processing doesn't handle nested classes.

 3. Jdk8Module was added to the ObjectMapper used for visiting the
    schema. (This is what actually handles the Optional<T> types.)

 4. jackson-datatype-jdk8 was added as a dependency to provide
    Jdk8Module.